### PR TITLE
[Part 12] Calling Source::close, Sink::close as part of stage execution.

### DIFF
--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/SinkPublisher.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/SinkPublisher.java
@@ -24,27 +24,34 @@ import io.mantisrx.runtime.SinkHolder;
 import io.mantisrx.runtime.StageConfig;
 import io.mantisrx.runtime.sink.Sink;
 import io.reactivex.mantis.remote.observable.RxMetrics;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 import rx.Subscriber;
+import rx.Subscription;
 import rx.functions.Action0;
 import rx.functions.Action1;
 
-
-public class SinkPublisher<T, R> implements WorkerPublisher<T, R> {
+/**
+ * Implementation that publishes the results of a stage to a sink such as an SSE port.
+ * @param <T>
+ */
+public class SinkPublisher<T> implements WorkerPublisher<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(SinkPublisher.class);
-    private SinkHolder<R> sinkHolder;
-    private PortSelector portSelector;
-    private Context context;
-    private Action0 observableTerminatedCallback;
-    private Action0 onSubscribeAction;
-    private Action0 onUnsubscribeAction;
-    private Action0 observableOnCompleteCallback;
-    private Action1<Throwable> observableOnErrorCallback;
+    private final SinkHolder<T> sinkHolder;
+    private final PortSelector portSelector;
+    private final Context context;
+    private final Action0 observableTerminatedCallback;
+    private final Action0 onSubscribeAction;
+    private final Action0 onUnsubscribeAction;
+    private final Action0 observableOnCompleteCallback;
+    private final Action1<Throwable> observableOnErrorCallback;
+    private Subscription eagerSubscription;
+    private Sink<T> sink;
 
-    public SinkPublisher(SinkHolder<R> sinkHolder,
+    public SinkPublisher(SinkHolder<T> sinkHolder,
                          PortSelector portSelector,
                          Context context,
                          Action0 observableTerminatedCallback, Action0 onSubscribeAction, Action0 onUnsubscribeAction,
@@ -61,9 +68,9 @@ public class SinkPublisher<T, R> implements WorkerPublisher<T, R> {
 
     @Override
     @SuppressWarnings( {"unchecked", "rawtypes"})
-    public void start(StageConfig<T, R> stage,
-                      Observable<Observable<R>> observablesToPublish) {
-        final Sink<R> sink = sinkHolder.getSinkAction();
+    public void start(StageConfig<?, T> stage,
+                      Observable<Observable<T>> observablesToPublish) {
+        sink = sinkHolder.getSinkAction();
 
         int sinkPort = -1;
         if (sinkHolder.isPortRequested()) {
@@ -72,7 +79,7 @@ public class SinkPublisher<T, R> implements WorkerPublisher<T, R> {
 
         // apply transform
 
-        Observable<R> merged = Observable.merge(observablesToPublish);
+        Observable<T> merged = Observable.merge(observablesToPublish);
         final Observable wrappedO = merged.lift(new MonitorOperator("worker_sink"));
 
         Observable o = Observable
@@ -101,17 +108,24 @@ public class SinkPublisher<T, R> implements WorkerPublisher<T, R> {
                 .share();
         if (context.getWorkerInfo().getDurationType() == MantisJobDurationType.Perpetual) {
             // eager subscribe, don't allow unsubscribe back
-            o.subscribe();
+            eagerSubscription = o.subscribe();
         }
         sink.init(context);
-        sink.call(context, new PortRequest(sinkPort),
-                o);
-        //o.lift(new DoOnRequestOperator("beforeShare")).share().lift(new DropOperator<>("sink_share")));
+        sink.call(context, new PortRequest(sinkPort), o);
     }
 
     @Override
     public RxMetrics getMetrics() {return null;}
 
     @Override
-    public void stop() {}
+    public void close() throws IOException {
+        try {
+            sink.close();
+        } finally {
+            if (eagerSubscription != null) {
+                eagerSubscription.unsubscribe();
+                eagerSubscription = null;
+            }
+        }
+    }
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerConsumer.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerConsumer.java
@@ -17,13 +17,17 @@
 package io.mantisrx.runtime.executor;
 
 import io.mantisrx.runtime.StageConfig;
+import java.io.Closeable;
 import rx.Observable;
 
+/**
+ * Abstraction for executing source observables. Source observables can be of two forms:
+ * 1). ones that consume from previous jobs or act as direct sources somehow
+ * 2). ones that consume from workers in previous stages.
+ *
+ * @param <T> type of the data that the observable emits
+ */
+public interface WorkerConsumer<T> extends Closeable {
 
-public interface WorkerConsumer<T, R> {
-
-    public Observable<Observable<T>> start(StageConfig<T, R> stage);
-
-    public void stop();
-
+    Observable<Observable<T>> start(StageConfig<T, ?> stage);
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerConsumerRemoteObservable.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerConsumerRemoteObservable.java
@@ -32,12 +32,12 @@ import io.reactivex.mantis.remote.observable.ConnectToObservable;
 import io.reactivex.mantis.remote.observable.DynamicConnectionSet;
 import io.reactivex.mantis.remote.observable.EndpointInjector;
 import io.reactivex.mantis.remote.observable.reconciliator.Reconciliator;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import rx.Observable;
 
-
-public class WorkerConsumerRemoteObservable<T, R> implements WorkerConsumer<T, R> {
+public class WorkerConsumerRemoteObservable<T, R> implements WorkerConsumer<T> {
 
     private static final Logger logger = LoggerFactory.getLogger(WorkerConsumerRemoteObservable.class);
 
@@ -55,7 +55,7 @@ public class WorkerConsumerRemoteObservable<T, R> implements WorkerConsumer<T, R
 
     @SuppressWarnings( {"rawtypes", "unchecked"})
     @Override
-    public Observable<Observable<T>> start(StageConfig<T, R> stage) {
+    public Observable<Observable<T>> start(StageConfig<T, ?> stage) {
         if (stage instanceof KeyToKey || stage instanceof KeyToScalar || stage instanceof GroupToScalar || stage instanceof GroupToGroup) {
 
             logger.info("Remote connection to stage " + name + " is KeyedStage");
@@ -100,6 +100,7 @@ public class WorkerConsumerRemoteObservable<T, R> implements WorkerConsumer<T, R
     }
 
     @Override
-    public void stop() {}
+    public void close() throws IOException {
+    }
 
 }

--- a/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerPublisher.java
+++ b/mantis-runtime/src/main/java/io/mantisrx/runtime/executor/WorkerPublisher.java
@@ -18,14 +18,16 @@ package io.mantisrx.runtime.executor;
 
 import io.mantisrx.runtime.StageConfig;
 import io.reactivex.mantis.remote.observable.RxMetrics;
+import java.io.Closeable;
 import rx.Observable;
 
+/**
+ * WorkerPublisher is an abstraction for a sink operator execution.
+ * @param <T> type of the observable that's getting published
+ */
+public interface WorkerPublisher<T> extends Closeable {
 
-public interface WorkerPublisher<T, R> {
+    void start(StageConfig<?, T> stage, Observable<Observable<T>> observableToPublish);
 
-    public void start(StageConfig<T, R> stage, Observable<Observable<R>> observableToPublish);
-
-    public RxMetrics getMetrics();
-
-    public void stop();
+    RxMetrics getMetrics();
 }


### PR DESCRIPTION
Before both the APIs were not available, we would get rid of the container as part of shutting down the workload. In the new Titus world, we want to gracefully shut down all the resources associated with the stage execution.

### Context

Explain context and other details for this pull request.

### Checklist

- [ ] `./gradlew build` compiles code correctly
- [ ] Added new tests where applicable
- [ ] `./gradlew test` passes all tests
- [ ] Extended README or added javadocs where applicable
- [ ] Added copyright headers for new files from `CONTRIBUTING.md`
